### PR TITLE
Artifact build and publishing introduction. MetricsProcessor move.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,12 +9,23 @@ buildscript {
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         buildDockerJdkVersion = System.getProperty("build.docker_jdk_ver", "11")
+
+        // 3.0.0-SNAPSHOT -> 3.0.0.0-SNAPSHOT
+        version_tokens = opensearch_version.tokenize('-')
+        opensearch_build = version_tokens[0] + '.0'
+        if (buildVersionQualifier) {
+            opensearch_build += "-${buildVersionQualifier}"
+        }
+        if (isSnapshot) {
+            opensearch_build += "-SNAPSHOT"
+        }
     }
 
     repositories {
         mavenLocal()
         mavenCentral()
         maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
+        maven { url "https://plugins.gradle.org/m2/" }
     }
 
     dependencies {
@@ -25,6 +36,8 @@ buildscript {
 }
 
 plugins {
+    id 'java'
+    id 'application'
     id 'java-library'
     id 'maven-publish'
     id 'com.diffplug.spotless' version '5.11.0'
@@ -51,18 +64,12 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
+    maven { url "https://plugins.gradle.org/m2/" }
 }
 
 allprojects {
     group 'org.opensearch.performanceanalyzer.commons'
-    version = '1.0.0'
-    if (buildVersionQualifier) {
-        version += "-${buildVersionQualifier}"
-    }
-
-    if (isSnapshot) {
-        version += "-SNAPSHOT"
-    }
+    version = opensearch_build
 }
 
 targetCompatibility = JavaVersion.VERSION_11
@@ -126,11 +133,36 @@ compileJava {
     dependsOn spotlessApply
 }
 
+distZip {
+    archiveName "performance-analyzer-commons-${version}.zip"
+}
+
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            groupId = 'org.opensearch'
+            artifactId = 'performanceanalyzer-commons'
+            from components.java
+        }
+    }
+}
+
 test {
     testLogging {
         exceptionFormat "full"
         events "skipped", "passed", "failed", "started"
         showStandardStreams true
+    }
+}
+
+distributions {
+    main {
+        contents {
+            eachFile {
+                it.path = it.path.replace("-$version/", '/')
+            }
+        }
     }
 }
 

--- a/src/main/java/org/opensearch/performanceanalyzer/commons/metrics/MetricsProcessor.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/commons/metrics/MetricsProcessor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.performanceanalyzer.commons.metrics;
+
+
+import org.opensearch.performanceanalyzer.commons.util.Util;
+
+public interface MetricsProcessor {
+
+    default String getMetricValues(long startTime, String... keysPath) {
+        return PerformanceAnalyzerMetrics.getMetric(getMetricsPath(startTime, keysPath));
+    }
+
+    default void saveMetricValues(String value, long startTime, String... keysPath) {
+        Util.invokePrivileged(
+                () ->
+                        PerformanceAnalyzerMetrics.emitMetric(
+                                PerformanceAnalyzerMetrics.getTimeInterval(
+                                        startTime, MetricsConfiguration.SAMPLING_INTERVAL),
+                                getMetricsPath(startTime, keysPath),
+                                value));
+    }
+
+    default String getMetricValue(String metricName, long startTime, String... keys) {
+        return PerformanceAnalyzerMetrics.extractMetricValue(
+                getMetricValues(startTime, keys), metricName);
+    }
+
+    String getMetricsPath(long startTime, String... keysPath);
+}


### PR DESCRIPTION
Introduced gradle change for artifact build and publishing. Moved in `MetricsProcessor` because of previously moved `PerformanceAnalyzerMetrics`.

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
