### PR TITLE
Fix minor error in isSnapshot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,9 +8,9 @@ buildscript {
         // Detect version from version.properties and align it with the build settings
         def build = new Properties()
         file("version.properties").withInputStream { build.load(it) }
-        var isSnapshot = "true" == System.getProperty("build.snapshot", "true")
+        var isSnapshot = System.getProperty("build.snapshot", "true")
         buildVersion = build.getProperty("version")
-        if (isSnapshot && !buildVersion.endsWith("SNAPSHOT")) {
+        if (isSnapshot.toBoolean() && !buildVersion.endsWith("SNAPSHOT")) {
             buildVersion = buildVersion + "-SNAPSHOT"
         } else if (!isSnapshot && buildVersion.endsWith("SNAPSHOT")) {
             throw GradleException("Expecting release (non-SNAPSHOT) build but version is not set accordingly: " + buildVersion)


### PR DESCRIPTION
Fix minor error in isSnapshot

```
BUILD SUCCESSFUL in 12s
8 actionable tasks: 8 executed
a repository
a repository/org
a repository/org/opensearch
a repository/org/opensearch/performance-analyzer-commons
a repository/org/opensearch/performance-analyzer-commons/maven-metadata.xml.sha256
a repository/org/opensearch/performance-analyzer-commons/1.0.0
a repository/org/opensearch/performance-analyzer-commons/maven-metadata.xml
a repository/org/opensearch/performance-analyzer-commons/maven-metadata.xml.sha512
a repository/org/opensearch/performance-analyzer-commons/maven-metadata.xml.md5
a repository/org/opensearch/performance-analyzer-commons/maven-metadata.xml.sha1
a repository/org/opensearch/performance-analyzer-commons/1.0.0/performance-analyzer-commons-1.0.0.pom
a repository/org/opensearch/performance-analyzer-commons/1.0.0/performance-analyzer-commons-1.0.0-sources.jar.md5
a repository/org/opensearch/performance-analyzer-commons/1.0.0/performance-analyzer-commons-1.0.0.pom.sha256
a repository/org/opensearch/performance-analyzer-commons/1.0.0/performance-analyzer-commons-1.0.0-javadoc.jar.sha1
a repository/org/opensearch/performance-analyzer-commons/1.0.0/performance-analyzer-commons-1.0.0-javadoc.jar.sha512
a repository/org/opensearch/performance-analyzer-commons/1.0.0/performance-analyzer-commons-1.0.0.pom.sha1
a repository/org/opensearch/performance-analyzer-commons/1.0.0/performance-analyzer-commons-1.0.0-sources.jar.sha256
a repository/org/opensearch/performance-analyzer-commons/1.0.0/performance-analyzer-commons-1.0.0-javadoc.jar.sha256
a repository/org/opensearch/performance-analyzer-commons/1.0.0/performance-analyzer-commons-1.0.0.pom.md5
a repository/org/opensearch/performance-analyzer-commons/1.0.0/performance-analyzer-commons-1.0.0.pom.sha512
a repository/org/opensearch/performance-analyzer-commons/1.0.0/performance-analyzer-commons-1.0.0-javadoc.jar
a repository/org/opensearch/performance-analyzer-commons/1.0.0/performance-analyzer-commons-1.0.0-sources.jar
a repository/org/opensearch/performance-analyzer-commons/1.0.0/performance-analyzer-commons-1.0.0-sources.jar.sha1
a repository/org/opensearch/performance-analyzer-commons/1.0.0/performance-analyzer-commons-1.0.0-javadoc.jar.md5
a repository/org/opensearch/performance-analyzer-commons/1.0.0/performance-analyzer-commons-1.0.0-sources.jar.sha512
```

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
