### PR TITLE
Update build.gradle to build main jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -194,7 +194,7 @@ publishing {
         create(MavenPublication) {
             groupId = 'org.opensearch'
             artifactId = 'performance-analyzer-commons'
-
+            from(components["java"])
             artifact sourcesJar
             artifact javadocJar
 


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
Update build.gradle to build main jar. Missing Main JAR is causing failure when publishing the JAR to Maven Central

Test:
```
% ls /Users/khushbr/.m2/repository/org/opensearch/performance-analyzer-commons/1.0.0
performance-analyzer-commons-1.0.0-javadoc.jar	performance-analyzer-commons-1.0.0.jar		performance-analyzer-commons-1.0.0.pom
performance-analyzer-commons-1.0.0-sources.jar	performance-analyzer-commons-1.0.0.module

```
### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
