### PR TITLE
SearchbackpressureStatsCollector Constants Added

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/commons/metrics/AllMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/commons/metrics/AllMetrics.java
@@ -935,7 +935,15 @@ public class AllMetrics {
                         .SEARCHBP_SEARCH_SHARD_TASK_STATS_LIMITREACHEDCOUNT),
         SEARCHBP_SEARCH_SHARD_TASK_STATS_RESOURCE_USAGE_TRACKER_STATS(
                 SearchBackPressureStatsValue.Constants
-                        .SEARCHBP_SEARCH_SHARD_TASK_STATS_RESOURCE_USAGE_TRACKER_STATS);
+                        .SEARCHBP_SEARCH_SHARD_TASK_STATS_RESOURCE_USAGE_TRACKER_STATS),
+        SEARCHBP_SEARCH_BACK_PRESSURE_STATS_SEARCH_SHARD_TASK_STATS(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_SEARCH_BACK_PRESSURE_STATS_SEARCH_SHARD_TASK_STATS),
+        SEARCHBP_SEARCH_BACK_PRESSURE_STATS_MODE(
+                SearchBackPressureStatsValue.Constants.SEARCHBP_SEARCH_BACK_PRESSURE_STATS_MODE),
+        SEARCHBP_SEARCH_BACK_PRESSURE_STATS_SEARCH_TASK_STATS(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_SEARCH_BACK_PRESSURE_STATS_SEARCH_TASK_STATS);
 
         private final String value;
 
@@ -949,8 +957,7 @@ public class AllMetrics {
         }
 
         public static class Constants {
-
-            // SearchBackPressure Stats
+            // SearchBackPressure Metrics
             public static final String SEARCHBP_MODE = "searchbp_mode";
             public static final String SEARCHBP_NODEID = "searchbp_nodeid";
             public static final String SEARCHBP_SHARD_STATS_CANCELLATIONCOUNT =
@@ -1024,6 +1031,12 @@ public class AllMetrics {
             public static final String
                     SEARCHBP_SEARCH_SHARD_TASK_STATS_RESOURCE_USAGE_TRACKER_STATS =
                             "resourceUsageTrackerStats";
+            // SearchBackPressureStats
+            public static final String SEARCHBP_SEARCH_BACK_PRESSURE_STATS_SEARCH_SHARD_TASK_STATS =
+                    "searchShardTaskStats";
+            public static final String SEARCHBP_SEARCH_BACK_PRESSURE_STATS_MODE = "mode";
+            public static final String SEARCHBP_SEARCH_BACK_PRESSURE_STATS_SEARCH_TASK_STATS =
+                    "searchTaskStats";
         }
     }
 

--- a/src/main/java/org/opensearch/performanceanalyzer/commons/metrics/AllMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/commons/metrics/AllMetrics.java
@@ -838,6 +838,195 @@ public class AllMetrics {
         }
     }
 
+    public enum SearchBackPressureStatsValue implements MetricValue {
+        SEARCHBP_MODE(SearchBackPressureStatsValue.Constants.SEARCHBP_MODE),
+        SEARCHBP_NODEID(SearchBackPressureStatsValue.Constants.SEARCHBP_NODEID),
+        SEARCHBP_SHARD_STATS_CANCELLATIONCOUNT(
+                SearchBackPressureStatsValue.Constants.SEARCHBP_SHARD_STATS_CANCELLATIONCOUNT),
+        SEARCHBP_SHARD_STATS_LIMITREACHEDCOUNT(
+                SearchBackPressureStatsValue.Constants.SEARCHBP_SHARD_STATS_LIMITREACHEDCOUNT),
+        SEARCHBP_SHARD_STATS_RESOURCE_HEAP_USAGE_CANCELLATIONCOUNT(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_SHARD_STATS_RESOURCE_HEAP_USAGE_CANCELLATIONCOUNT),
+        SEARCHBP_SHARD_STATS_RESOURCE_HEAP_USAGE_CURRENTMAX(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_SHARD_STATS_RESOURCE_HEAP_USAGE_CURRENTMAX),
+        SEARCHBP_SHARD_STATS_RESOURCE_HEAP_USAGE_ROLLINGAVG(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_SHARD_STATS_RESOURCE_HEAP_USAGE_ROLLINGAVG),
+        SEARCHBP_SHARD_STATS_RESOURCE_CPU_USAGE_CANCELLATIONCOUNT(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_SHARD_STATS_RESOURCE_CPU_USAGE_CANCELLATIONCOUNT),
+        SEARCHBP_SHARD_STATS_RESOURCE_CPU_USAGE_CURRENTMAX(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_SHARD_STATS_RESOURCE_CPU_USAGE_CURRENTMAX),
+        SEARCHBP_SHARD_STATS_RESOURCE_CPU_USAGE_CURRENTAVG(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_SHARD_STATS_RESOURCE_CPU_USAGE_CURRENTAVG),
+        SEARCHBP_SHARD_STATS_RESOURCE_ELASPEDTIME_USAGE_CANCELLATIONCOUNT(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_SHARD_STATS_RESOURCE_ELASPEDTIME_USAGE_CANCELLATIONCOUNT),
+        SEARCHBP_SHARD_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENTMAX(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_SHARD_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENTMAX),
+        SEARCHBP_SHARD_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENTAVG(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_SHARD_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENTAVG),
+        SEARCHBP_TASK_STATS_CANCELLATIONCOUNT(
+                SearchBackPressureStatsValue.Constants.SEARCHBP_TASK_STATS_CANCELLATIONCOUNT),
+        SEARCHBP_TASK_STATS_LIMITREACHEDCOUNT(
+                SearchBackPressureStatsValue.Constants.SEARCHBP_TASK_STATS_LIMITREACHEDCOUNT),
+        SEARCHBP_TASK_STATS_RESOURCE_HEAP_USAGE_CANCELLATIONCOUNT(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_TASK_STATS_RESOURCE_HEAP_USAGE_CANCELLATIONCOUNT),
+        SEARCHBP_TASK_STATS_RESOURCE_HEAP_USAGE_CURRENTMAX(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_TASK_STATS_RESOURCE_HEAP_USAGE_CURRENTMAX),
+        SEARCHBP_TASK_STATS_RESOURCE_HEAP_USAGE_ROLLINGAVG(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_TASK_STATS_RESOURCE_HEAP_USAGE_ROLLINGAVG),
+        SEARCHBP_TASK_STATS_RESOURCE_CPU_USAGE_CANCELLATIONCOUNT(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_TASK_STATS_RESOURCE_CPU_USAGE_CANCELLATIONCOUNT),
+        SEARCHBP_TASK_STATS_RESOURCE_CPU_USAGE_CURRENTMAX(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_TASK_STATS_RESOURCE_CPU_USAGE_CURRENTMAX),
+        SEARCHBP_TASK_STATS_RESOURCE_CPU_USAGE_CURRENTAVG(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_TASK_STATS_RESOURCE_CPU_USAGE_CURRENTAVG),
+        SEARCHBP_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CANCELLATIONCOUNT(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CANCELLATIONCOUNT),
+        SEARCHBP_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENTMAX(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENTMAX),
+        SEARCHBP_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENTAVG(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENTAVG),
+        SEARCHBP_RESOURCE_USAGE_TRACKER_STATS_CANCELLATIONCOUNT(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_RESOURCE_USAGE_TRACKER_STATS_CANCELLATIONCOUNT),
+        SEARCHBP_RESOURCE_USAGE_TRACKER_STATS_CURRENTMAX(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_RESOURCE_USAGE_TRACKER_STATS_CURRENTMAX),
+        SEARCHBP_RESOURCE_USAGE_TRACKER_STATS_CURRENTAVG(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_RESOURCE_USAGE_TRACKER_STATS_CURRENTAVG),
+        SEARCHBP_RESOURCE_USAGE_TRACKER_STATS_ROLLINGAVG(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_RESOURCE_USAGE_TRACKER_STATS_ROLLINGAVG),
+        SEARCHBP_RESOURCE_USAGE_TRACKER_STATS_FRAGMENT(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_RESOURCE_USAGE_TRACKER_STATS_FRAGMENT),
+        SEARCHBP_SEARCH_TASK_STATS_CANCELLATIONCOUNT(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_SEARCH_TASK_STATS_CANCELLATIONCOUNT),
+        SEARCHBP_SEARCH_TASK_STATS_LIMITREACHEDCOUNT(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_SEARCH_TASK_STATS_LIMITREACHEDCOUNT),
+        SEARCHBP_SEARCH_TASK_STATS_RESOURCE_USAGE_TRACKER_STATS(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_SEARCH_TASK_STATS_RESOURCE_USAGE_TRACKER_STATS),
+        SEARCHBP_SEARCH_SHARD_TASK_STATS_CANCELLATIONCOUNT(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_SEARCH_SHARD_TASK_STATS_CANCELLATIONCOUNT),
+        SEARCHBP_SEARCH_SHARD_TASK_STATS_LIMITREACHEDCOUNT(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_SEARCH_SHARD_TASK_STATS_LIMITREACHEDCOUNT),
+        SEARCHBP_SEARCH_SHARD_TASK_STATS_RESOURCE_USAGE_TRACKER_STATS(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_SEARCH_SHARD_TASK_STATS_RESOURCE_USAGE_TRACKER_STATS);
+
+        private final String value;
+
+        SearchBackPressureStatsValue(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+
+        public static class Constants {
+
+            // SearchBackPressure Stats
+            public static final String SEARCHBP_MODE = "searchbp_mode";
+            public static final String SEARCHBP_NODEID = "searchbp_nodeid";
+            public static final String SEARCHBP_SHARD_STATS_CANCELLATIONCOUNT =
+                    "searchbp_shard_stats_cancellationCount";
+            public static final String SEARCHBP_SHARD_STATS_LIMITREACHEDCOUNT =
+                    "searchbp_shard_stats_limitReachedCount";
+            public static final String SEARCHBP_SHARD_STATS_RESOURCE_HEAP_USAGE_CANCELLATIONCOUNT =
+                    "searchbp_shard_stats_resource_heap_usage_cancellationCount";
+            public static final String SEARCHBP_SHARD_STATS_RESOURCE_HEAP_USAGE_CURRENTMAX =
+                    "searchbp_shard_stats_resource_heap_usage_currentMax";
+            public static final String SEARCHBP_SHARD_STATS_RESOURCE_HEAP_USAGE_ROLLINGAVG =
+                    "searchbp_shard_stats_resource_heap_usage_rollingAvg";
+            public static final String SEARCHBP_SHARD_STATS_RESOURCE_CPU_USAGE_CANCELLATIONCOUNT =
+                    "searchbp_shard_stats_resource_cpu_usage_cancellationCount";
+            public static final String SEARCHBP_SHARD_STATS_RESOURCE_CPU_USAGE_CURRENTMAX =
+                    "searchbp_shard_stats_resource_cpu_usage_currentMax";
+            public static final String SEARCHBP_SHARD_STATS_RESOURCE_CPU_USAGE_CURRENTAVG =
+                    "searchbp_shard_stats_resource_cpu_usage_currentAvg";
+            public static final String
+                    SEARCHBP_SHARD_STATS_RESOURCE_ELASPEDTIME_USAGE_CANCELLATIONCOUNT =
+                            "searchbp_shard_stats_resource_elaspedtime_usage_cancellationCount";
+            public static final String SEARCHBP_SHARD_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENTMAX =
+                    "searchbp_shard_stats_resource_elaspedtime_usage_currentMax";
+            public static final String SEARCHBP_SHARD_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENTAVG =
+                    "searchbp_shard_stats_resource_elaspedtime_usage_currentAvg";
+            public static final String SEARCHBP_TASK_STATS_CANCELLATIONCOUNT =
+                    "searchbp_task_stats_cancellationCount";
+            public static final String SEARCHBP_TASK_STATS_LIMITREACHEDCOUNT =
+                    "searchbp_task_stats_limitReachedCount";
+            public static final String SEARCHBP_TASK_STATS_RESOURCE_HEAP_USAGE_CANCELLATIONCOUNT =
+                    "searchbp_task_stats_resource_heap_usage_cancellationCount";
+            public static final String SEARCHBP_TASK_STATS_RESOURCE_HEAP_USAGE_CURRENTMAX =
+                    "searchbp_task_stats_resource_heap_usage_currentMax";
+            public static final String SEARCHBP_TASK_STATS_RESOURCE_HEAP_USAGE_ROLLINGAVG =
+                    "searchbp_task_stats_resource_heap_usage_rollingAvg";
+            public static final String SEARCHBP_TASK_STATS_RESOURCE_CPU_USAGE_CANCELLATIONCOUNT =
+                    "searchbp_task_stats_resource_cpu_usage_cancellationCount";
+            public static final String SEARCHBP_TASK_STATS_RESOURCE_CPU_USAGE_CURRENTMAX =
+                    "searchbp_task_stats_resource_cpu_usage_currentMax";
+            public static final String SEARCHBP_TASK_STATS_RESOURCE_CPU_USAGE_CURRENTAVG =
+                    "searchbp_task_stats_resource_cpu_usage_currentAvg";
+            public static final String
+                    SEARCHBP_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CANCELLATIONCOUNT =
+                            "searchbp_task_stats_resource_elaspedtime_usage_cancellationCount";
+            public static final String SEARCHBP_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENTMAX =
+                    "searchbp_task_stats_resource_elaspedtime_usage_currentMax";
+            public static final String SEARCHBP_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENTAVG =
+                    "searchbp_task_stats_resource_elaspedtime_usage_currentAvg";
+            // ResourceUsageTrackerStats
+            public static final String SEARCHBP_RESOURCE_USAGE_TRACKER_STATS_CANCELLATIONCOUNT =
+                    "cancellationCount";
+            public static final String SEARCHBP_RESOURCE_USAGE_TRACKER_STATS_CURRENTMAX =
+                    "currentMax";
+            public static final String SEARCHBP_RESOURCE_USAGE_TRACKER_STATS_CURRENTAVG =
+                    "currentAvg";
+            public static final String SEARCHBP_RESOURCE_USAGE_TRACKER_STATS_ROLLINGAVG =
+                    "rollingAvg";
+            public static final String SEARCHBP_RESOURCE_USAGE_TRACKER_STATS_FRAGMENT = "fragment";
+            // SearchTaskStats
+            public static final String SEARCHBP_SEARCH_TASK_STATS_CANCELLATIONCOUNT =
+                    "cancellationCount";
+            public static final String SEARCHBP_SEARCH_TASK_STATS_LIMITREACHEDCOUNT =
+                    "limitReachedCount";
+            public static final String SEARCHBP_SEARCH_TASK_STATS_RESOURCE_USAGE_TRACKER_STATS =
+                    "resourceUsageTrackerStats";
+            // SearchShardTaskStats
+            public static final String SEARCHBP_SEARCH_SHARD_TASK_STATS_CANCELLATIONCOUNT =
+                    "cancellationCount";
+            public static final String SEARCHBP_SEARCH_SHARD_TASK_STATS_LIMITREACHEDCOUNT =
+                    "limitReachedCount";
+            public static final String
+                    SEARCHBP_SEARCH_SHARD_TASK_STATS_RESOURCE_USAGE_TRACKER_STATS =
+                            "resourceUsageTrackerStats";
+        }
+    }
+
     public enum ClusterManagerClusterUpdateStatsValue implements MetricValue {
         PUBLISH_CLUSTER_STATE_LATENCY(Constants.PUBLISH_CLUSTER_STATE_LATENCY),
         PUBLISH_CLUSTER_STATE_FAILURE(Constants.PUBLISH_CLUSTER_STATE_FAILURE);


### PR DESCRIPTION
Signed-off-by: Jeffrey Liu [ujeffliu@amazon.com](mailto:ujeffliu@amazon.com)

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
The SearchBackpressureStatsCollector.java added in pull & request (https://github.com/opensearch-project/performance-analyzer/pull/483) use literal String value (e.g. "searchbp_nodeid"0 for json field, which is not aligned with instance accessing and coding styles with other collectors.

**Describe the solution you are proposing**
Added all required Constants needed by SearchbackPressureStatsCollector.java to populate the jsonFields

Example: 
`    @JsonProperty("searchbp_nodeid")
        public String getSearchBackPressureStats_NodeId() {
            return this.nodeId;
        }`
   
Has changed to:
` @JsonProperty(SearchBackPressureStatsValue.Constants.SEARCHBP_NODEID)
        public String getSearchBackPressureStats_NodeId() {
            return this.nodeId;
        }`

**Describe alternatives you've considered**
N/A

**Additional context**
Parallel Pull & Request with https://github.com/opensearch-project/performance-analyzer/pull/483
**This Commons Package PR (SearchbackpressureStatsCollector Constants Added #33 ) is needed in order to run the parallel PA-plugin PR.**

### Check List
- [X] New functionality includes testing.
- [X] All tests pass
- [X] New functionality has been documented.
- [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
