### PR TITLE
Constants added for searchbackpressure rca reader to consume searchbackpressure metrics in shared folder

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/commons/metrics/AllMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/commons/metrics/AllMetrics.java
@@ -1040,12 +1040,14 @@ public class AllMetrics {
             public static final String SEARCHBP_SEARCH_BACK_PRESSURE_STATS_SEARCH_TASK_STATS =
                     "searchTaskStats";
 
-            /*
-             * General Info
+
+            /**
              * Add SEARCHBP_TABLE_NAME for searchbackpressureRCA to find the corresponding table
-             * Add SEARCHBP_TYPE_DIM for searchbackpressureRCA to find the cell value for each stats type
              */
             public static final String SEARCHBP_TABLE_NAME = "Searchbp_Stats";
+            /**
+             * Add SEARCHBP_TYPE_DIM for searchbackpressureRCA to find the cell value for each stats type
+             */
             public static final String SEARCHBP_TYPE_DIM = "SearchBackPressureStats";
         }
     }

--- a/src/main/java/org/opensearch/performanceanalyzer/commons/metrics/AllMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/commons/metrics/AllMetrics.java
@@ -944,12 +944,10 @@ public class AllMetrics {
         SEARCHBP_SEARCH_BACK_PRESSURE_STATS_SEARCH_TASK_STATS(
                 SearchBackPressureStatsValue.Constants
                         .SEARCHBP_SEARCH_BACK_PRESSURE_STATS_SEARCH_TASK_STATS),
-        SEARCHBP_TABLE_NAME(
-            SearchBackPressureStatsValue.Constants.SEARCHBP_TABLE_NAME),
-        SEARCHBP_TYPE_DIM(
-            SearchBackPressureStatsValue.Constants.SEARCHBP_TYPE_DIM);
+        SEARCHBP_TABLE_NAME(SearchBackPressureStatsValue.Constants.SEARCHBP_TABLE_NAME),
+        SEARCHBP_TYPE_DIM(SearchBackPressureStatsValue.Constants.SEARCHBP_TYPE_DIM);
 
-        private final String value; 
+        private final String value;
 
         SearchBackPressureStatsValue(String value) {
             this.value = value;
@@ -1042,10 +1040,12 @@ public class AllMetrics {
             public static final String SEARCHBP_SEARCH_BACK_PRESSURE_STATS_SEARCH_TASK_STATS =
                     "searchTaskStats";
 
-            // General Info 
-            // Table Name stored in sqlitedb
+            /*
+             * General Info
+             * Add SEARCHBP_TABLE_NAME for searchbackpressureRCA to find the corresponding table
+             * Add SEARCHBP_TYPE_DIM for searchbackpressureRCA to find the cell value for each stats type
+             */
             public static final String SEARCHBP_TABLE_NAME = "Searchbp_Stats";
-            // Column Names for difference stats stored in sqlitedb
             public static final String SEARCHBP_TYPE_DIM = "SearchBackPressureStats";
         }
     }

--- a/src/main/java/org/opensearch/performanceanalyzer/commons/metrics/AllMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/commons/metrics/AllMetrics.java
@@ -943,9 +943,13 @@ public class AllMetrics {
                 SearchBackPressureStatsValue.Constants.SEARCHBP_SEARCH_BACK_PRESSURE_STATS_MODE),
         SEARCHBP_SEARCH_BACK_PRESSURE_STATS_SEARCH_TASK_STATS(
                 SearchBackPressureStatsValue.Constants
-                        .SEARCHBP_SEARCH_BACK_PRESSURE_STATS_SEARCH_TASK_STATS);
+                        .SEARCHBP_SEARCH_BACK_PRESSURE_STATS_SEARCH_TASK_STATS),
+        SEARCHBP_TABLE_NAME(
+            SearchBackPressureStatsValue.Constants.SEARCHBP_TABLE_NAME),
+        SEARCHBP_TYPE_DIM(
+            SearchBackPressureStatsValue.Constants.SEARCHBP_TYPE_DIM);
 
-        private final String value;
+        private final String value; 
 
         SearchBackPressureStatsValue(String value) {
             this.value = value;
@@ -1037,6 +1041,12 @@ public class AllMetrics {
             public static final String SEARCHBP_SEARCH_BACK_PRESSURE_STATS_MODE = "mode";
             public static final String SEARCHBP_SEARCH_BACK_PRESSURE_STATS_SEARCH_TASK_STATS =
                     "searchTaskStats";
+
+            // General Info 
+            // Table Name stored in sqlitedb
+            public static final String SEARCHBP_TABLE_NAME = "Searchbp_Stats";
+            // Column Names for difference stats stored in sqlitedb
+            public static final String SEARCHBP_TYPE_DIM = "SearchBackPressureStats";
         }
     }
 

--- a/src/main/java/org/opensearch/performanceanalyzer/commons/metrics/PerformanceAnalyzerMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/commons/metrics/PerformanceAnalyzerMetrics.java
@@ -52,6 +52,7 @@ public class PerformanceAnalyzerMetrics {
     public static final String sGcInfoPath = "gc_info";
     public static final String sMountedPartitionMetricsPath = "mounted_part_space";
     public static final String sAdmissionControlMetricsPath = "admission_control_metrics";
+    public static final String sSearchBackPressureMetricsPath = "search_back_pressure";
     public static final String sShardIndexingPressurePath = "shard_indexing_pressure_metrics";
     public static final String sKeyValueDelimitor = ":";
     public static final String sMetricNewLineDelimitor = System.getProperty("line.separator");


### PR DESCRIPTION
(Signed off-by: Jeffrey Liu ujeffliu@amazon.com)

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

**Describe the solution you are proposing**
To fix on issue https://github.com/opensearch-project/performance-analyzer-rca/issues/424. The PR mainly adds constatns required forthe reader to consume SearchBackPressure Service metrics.

**Describe alternatives you've considered**
N/A

**Additional context**
- Parallel Request for PR #427 for Performance-Analyzer-RCA (https://github.com/opensearch-project/performance-analyzer-rca/pull/427)
- Must approve this PR for the parallel PR to be passed the Build Test


### Check List
- [X] New functionality includes testing.
- [X] All tests pass
- [X] New functionality has been documented.
- [X] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
