### PR TITLE
test: add ThreadSchedTests

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/commons/os/ThreadSched.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/commons/os/ThreadSched.java
@@ -6,6 +6,7 @@
 package org.opensearch.performanceanalyzer.commons.os;
 
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -137,7 +138,11 @@ public final class ThreadSched {
     }
 
     public synchronized SchedMetricsGenerator getSchedLatency() {
-
         return schedLatencyMap;
+    }
+
+    @VisibleForTesting
+    public Map<String, Map<String, Object>> getTidKVMap() {
+        return this.tidKVMap;
     }
 }

--- a/src/main/java/org/opensearch/performanceanalyzer/commons/os/ThreadSched.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/commons/os/ThreadSched.java
@@ -10,6 +10,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ParameterizedMessage;
@@ -36,6 +37,27 @@ public final class ThreadSched {
             this.avgRuntime = avgRuntime;
             this.avgWaittime = avgWaittime;
             this.contextSwitchRate = contextSwitchRate;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.avgRuntime, this.avgWaittime, this.contextSwitchRate);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            SchedMetrics other = (SchedMetrics) o;
+
+            return Double.compare(avgRuntime, other.avgRuntime) == 0
+                    && Double.compare(avgWaittime, other.avgWaittime) == 0
+                    && Double.compare(contextSwitchRate, other.contextSwitchRate) == 0;
         }
 
         @Override

--- a/src/test/java/org/opensearch/performanceanalyzer/commons/os/ThreadSchedTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/commons/os/ThreadSchedTests.java
@@ -8,13 +8,14 @@ package org.opensearch.performanceanalyzer.commons.os;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.verify;
 
 import java.util.List;
 import java.util.Map;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
+import org.opensearch.performanceanalyzer.commons.metrics_generator.linux.LinuxSchedMetricsGenerator;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -30,25 +31,61 @@ public class ThreadSchedTests {
 
     private Map<String, Map<String, Object>> tidKVMap =
             Map.of(
-                    "1", Map.of("runticks", "1", "waitticks", "2", "totctxsws", "3"),
-                    "2", Map.of("runticks", "4", "waitticks", "5", "totctxsws", "6"),
-                    "3", Map.of("runticks", "7", "waitticks", "8", "totctxsws", "9"));
+                    "1", Map.of("runticks", 100000000L, "waitticks", 100000000L, "totctxsws", 100L),
+                    "2", Map.of("runticks", 100000000L, "waitticks", 100000000L, "totctxsws", 10L),
+                    "3",
+                            Map.of(
+                                    "runticks",
+                                    500000000L,
+                                    "waitticks",
+                                    500000000L,
+                                    "totctxsws",
+                                    120L));
 
-    @Before
-    public void setUp() throws Exception {
+    private Map<String, Map<String, Object>> nextTidKVMap =
+            Map.of(
+                    "1", Map.of("runticks", 200000000L, "waitticks", 200000000L, "totctxsws", 200L),
+                    "2", Map.of("runticks", 500000000L, "waitticks", 500000000L, "totctxsws", 20L),
+                    "3",
+                            Map.of(
+                                    "runticks",
+                                    700000000L,
+                                    "waitticks",
+                                    700000000L,
+                                    "totctxsws",
+                                    220L));
+
+    @Test
+    public void testMetrics() throws Exception {
+        // this test checks that
+        // 1. ThreadSched calls the SchemaFileParser constructor with the correct path
+        // 2. ThreadSched calculates the correct metrics from procfile data
+
         // mock OSGlobals
         PowerMockito.mockStatic(OSGlobals.class);
         PowerMockito.when(OSGlobals.getPid()).thenReturn("0");
         PowerMockito.when(OSGlobals.getTids()).thenReturn(List.of("1", "2", "3"));
-    }
 
-    @Test
-    public void testMetrics() throws Exception {
+        // mock System.currentTimeMillis()
+        // used by ThreadSched to compute SchedMetric
+        PowerMockito.mockStatic(System.class);
+        // having the time difference = 1000ms
+        // means that contextSwitchRate = difference in totctxsws
+        PowerMockito.when(System.currentTimeMillis()).thenReturn(10L, 1010L);
+
+        // mock the metrics generator used by ThreadSched
+        LinuxSchedMetricsGenerator linuxSchedMetricsGenerator =
+                Mockito.mock(LinuxSchedMetricsGenerator.class);
+        PowerMockito.whenNew(LinuxSchedMetricsGenerator.class)
+                .withNoArguments()
+                .thenReturn(linuxSchedMetricsGenerator);
+
         // mock SchemaFileParser (used by ThreadSched to read procfiles)
         SchemaFileParser schemaFileParser = Mockito.mock(SchemaFileParser.class);
 
         PowerMockito.when(schemaFileParser.parse())
-                .thenReturn(tidKVMap.get("1"), tidKVMap.get("2"), tidKVMap.get("3"));
+                .thenReturn(tidKVMap.get("1"), tidKVMap.get("2"), tidKVMap.get("3"))
+                .thenReturn(nextTidKVMap.get("1"), nextTidKVMap.get("2"), nextTidKVMap.get("3"));
 
         PowerMockito.whenNew(SchemaFileParser.class)
                 .withAnyArguments()
@@ -75,5 +112,15 @@ public class ThreadSchedTests {
                         isA(SchemaFileParser.FieldTypes[].class));
 
         assertEquals(tidKVMap, ThreadSched.INSTANCE.getTidKVMap());
+
+        ThreadSched.INSTANCE.addSample();
+
+        // verify that the metrics generator is given correct metrics
+        verify(linuxSchedMetricsGenerator)
+                .setSchedMetric("1", new ThreadSched.SchedMetrics(0.001, 0.001, 100.0));
+        verify(linuxSchedMetricsGenerator)
+                .setSchedMetric("2", new ThreadSched.SchedMetrics(0.04, 0.04, 10.0));
+        verify(linuxSchedMetricsGenerator)
+                .setSchedMetric("3", new ThreadSched.SchedMetrics(0.002, 0.002, 100.0));
     }
 }

--- a/src/test/java/org/opensearch/performanceanalyzer/commons/os/ThreadSchedTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/commons/os/ThreadSchedTests.java
@@ -5,20 +5,75 @@
 
 package org.opensearch.performanceanalyzer.commons.os;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
+import org.powermock.modules.junit4.PowerMockRunner;
 
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore("javax.management.*")
+@SuppressStaticInitializationFor({"org.opensearch.performanceanalyzer.commons.os.OSGlobals"})
+// whenNew requires the class calling the constructor to be PreparedForTest
+@PrepareForTest({SchemaFileParser.class, OSGlobals.class, ThreadSched.class})
 public class ThreadSchedTests {
-    public static void main(String[] args) throws Exception {
-        runOnce();
+
+    private Map<String, Map<String, Object>> tidKVMap =
+            Map.of(
+                    "1", Map.of("runticks", "1", "waitticks", "2", "totctxsws", "3"),
+                    "2", Map.of("runticks", "4", "waitticks", "5", "totctxsws", "6"),
+                    "3", Map.of("runticks", "7", "waitticks", "8", "totctxsws", "9"));
+
+    @Before
+    public void setUp() throws Exception {
+        // mock OSGlobals
+        PowerMockito.mockStatic(OSGlobals.class);
+        PowerMockito.when(OSGlobals.getPid()).thenReturn("0");
+        PowerMockito.when(OSGlobals.getTids()).thenReturn(List.of("1", "2", "3"));
     }
 
-    public static void runOnce() {
-        ThreadSched.INSTANCE.addSample();
-        System.out.println(ThreadSched.INSTANCE.getSchedLatency().toString());
-    }
-
-    // - to enhance
     @Test
-    public void testMetrics() {}
+    public void testMetrics() throws Exception {
+        // mock SchemaFileParser (used by ThreadSched to read procfiles)
+        SchemaFileParser schemaFileParser = Mockito.mock(SchemaFileParser.class);
+
+        PowerMockito.when(schemaFileParser.parse())
+                .thenReturn(tidKVMap.get("1"), tidKVMap.get("2"), tidKVMap.get("3"));
+
+        PowerMockito.whenNew(SchemaFileParser.class)
+                .withAnyArguments()
+                .thenReturn(schemaFileParser);
+
+        ThreadSched.INSTANCE.addSample();
+
+        // assert that ThreadSched calls the SchemaFileParser constructor with the
+        // correct path
+        PowerMockito.verifyNew(SchemaFileParser.class)
+                .withArguments(
+                        eq("/proc/0/task/1/schedstat"),
+                        isA(String[].class),
+                        isA(SchemaFileParser.FieldTypes[].class));
+        PowerMockito.verifyNew(SchemaFileParser.class)
+                .withArguments(
+                        eq("/proc/0/task/2/schedstat"),
+                        isA(String[].class),
+                        isA(SchemaFileParser.FieldTypes[].class));
+        PowerMockito.verifyNew(SchemaFileParser.class)
+                .withArguments(
+                        eq("/proc/0/task/3/schedstat"),
+                        isA(String[].class),
+                        isA(SchemaFileParser.FieldTypes[].class));
+
+        assertEquals(tidKVMap, ThreadSched.INSTANCE.getTidKVMap());
+    }
 }


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
Add tests for `os/ThreadSched.java`.

### Check List
- [X] New functionality includes testing.
  - [x] All tests pass
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

```
➜  ~/opensearch/performance-analyzer-commons ./gradlew test --tests ThreadSchedTests                                   

> Task :test

org.opensearch.performanceanalyzer.commons.os.ThreadSchedTests > testMetrics STARTED

org.opensearch.performanceanalyzer.commons.os.ThreadSchedTests > testMetrics PASSED

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.6.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 8s
```
