### PR TITLE
Add separate metric for cluster manager service events and metrics

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/commons/stats/metrics/StatExceptionCode.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/commons/stats/metrics/StatExceptionCode.java
@@ -82,14 +82,15 @@ public enum StatExceptionCode {
     CACHE_CONFIG_METRICS_COLLECTOR_ERROR("CacheConfigMetricsCollectorError"),
     ADMISSION_CONTROL_COLLECTOR_ERROR("AdmissionControlCollectorError"),
     CIRCUIT_BREAKER_COLLECTOR_ERROR("CircuitBreakerCollectorError"),
-    CLUSTER_MANAGER_METRICS_ERROR("ClusterManagerMetricsError"),
-    CLUSTER_MANAGER_NODE_NOT_UP("ClusterManagerNodeNotUp"),
+    CLUSTER_MANAGER_SERVICE_EVENTS_METRICS_COLLECTOR_ERROR("ClusterManagerServiceEventsMetricsCollectorError"),
+    CLUSTER_MANAGER_SERVICE_METRICS_COLLECTOR_ERROR("ClusterManagerServiceMetricsCollectorError"),
     CLUSTER_MANAGER_THROTTLING_COLLECTOR_ERROR("ClusterManagerThrottlingMetricsCollectorError"),
     FAULT_DETECTION_COLLECTOR_ERROR("FaultDetectionMetricsCollectorError"),
     CLUSTER_APPLIER_SERVICE_STATS_COLLECTOR_ERROR("ClusterApplierServiceStatsCollectorError"),
     ELECTION_TERM_COLLECTOR_ERROR("ElectionTermCollectorError"),
     SHARD_INDEXING_PRESSURE_COLLECTOR_ERROR("ShardIndexingPressureMetricsCollectorError"),
     NODESTATS_COLLECTION_ERROR("NodeStatsCollectionError"),
+    CLUSTER_MANAGER_NODE_NOT_UP("ClusterManagerNodeNotUp"),
 
     /** Below tracks Reader specific Errors. */
     READER_ERROR_PA_DISABLE_SUCCESS("ReaderErrorPADisableSuccess"),


### PR DESCRIPTION
Add separate metric for cluster manager service events and metrics

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
