### PR TITLE
add completionCount constants for co-ordinator and shard level tasks

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/commons/metrics/AllMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/commons/metrics/AllMetrics.java
@@ -841,70 +841,76 @@ public class AllMetrics {
     public enum SearchBackPressureStatsValue implements MetricValue {
         SEARCHBP_MODE(SearchBackPressureStatsValue.Constants.SEARCHBP_MODE),
         SEARCHBP_NODEID(SearchBackPressureStatsValue.Constants.SEARCHBP_NODEID),
-        SEARCHBP_SHARD_STATS_CANCELLATIONCOUNT(
-                SearchBackPressureStatsValue.Constants.SEARCHBP_SHARD_STATS_CANCELLATIONCOUNT),
-        SEARCHBP_SHARD_STATS_LIMITREACHEDCOUNT(
-                SearchBackPressureStatsValue.Constants.SEARCHBP_SHARD_STATS_LIMITREACHEDCOUNT),
-        SEARCHBP_SHARD_STATS_COMPLETIONCOUNT(Constants.SEARCHBP_SHARD_STATS_COMPLETIONCOUNT),
-        SEARCHBP_SHARD_STATS_RESOURCE_HEAP_USAGE_CANCELLATIONCOUNT(
+        SEARCHBP_SHARD_TASK_STATS_CANCELLATION_COUNT(
                 SearchBackPressureStatsValue.Constants
-                        .SEARCHBP_SHARD_STATS_RESOURCE_HEAP_USAGE_CANCELLATIONCOUNT),
-        SEARCHBP_SHARD_STATS_RESOURCE_HEAP_USAGE_CURRENTMAX(
+                        .SEARCHBP_SHARD_TASK_STATS_CANCELLATION_COUNT),
+        SEARCHBP_SHARD_TASK_STATS_LIMIT_REACHED_COUNT(
                 SearchBackPressureStatsValue.Constants
-                        .SEARCHBP_SHARD_STATS_RESOURCE_HEAP_USAGE_CURRENTMAX),
-        SEARCHBP_SHARD_STATS_RESOURCE_HEAP_USAGE_ROLLINGAVG(
+                        .SEARCHBP_SHARD_TASK_STATS_LIMIT_REACHED_COUNT),
+        SEARCHBP_SHARD_TASK_STATS_COMPLETION_COUNT(
+                Constants.SEARCHBP_SHARD_TASK_STATS_COMPLETION_COUNT),
+        SEARCHBP_SHARD_TASK_STATS_RESOURCE_HEAP_USAGE_CANCELLATION_COUNT(
                 SearchBackPressureStatsValue.Constants
-                        .SEARCHBP_SHARD_STATS_RESOURCE_HEAP_USAGE_ROLLINGAVG),
-        SEARCHBP_SHARD_STATS_RESOURCE_CPU_USAGE_CANCELLATIONCOUNT(
+                        .SEARCHBP_SHARD_TASK_STATS_RESOURCE_HEAP_USAGE_CANCELLATION_COUNT),
+        SEARCHBP_SHARD_TASK_STATS_RESOURCE_HEAP_USAGE_CURRENT_MAX(
                 SearchBackPressureStatsValue.Constants
-                        .SEARCHBP_SHARD_STATS_RESOURCE_CPU_USAGE_CANCELLATIONCOUNT),
-        SEARCHBP_SHARD_STATS_RESOURCE_CPU_USAGE_CURRENTMAX(
+                        .SEARCHBP_SHARD_TASK_STATS_RESOURCE_HEAP_USAGE_CURRENT_MAX),
+        SEARCHBP_SHARD_TASK_STATS_RESOURCE_HEAP_USAGE_ROLLING_AVG(
                 SearchBackPressureStatsValue.Constants
-                        .SEARCHBP_SHARD_STATS_RESOURCE_CPU_USAGE_CURRENTMAX),
-        SEARCHBP_SHARD_STATS_RESOURCE_CPU_USAGE_CURRENTAVG(
+                        .SEARCHBP_SHARD_TASK_STATS_RESOURCE_HEAP_USAGE_ROLLING_AVG),
+        SEARCHBP_SHARD_TASK_STATS_RESOURCE_CPU_USAGE_CANCELLATION_COUNT(
                 SearchBackPressureStatsValue.Constants
-                        .SEARCHBP_SHARD_STATS_RESOURCE_CPU_USAGE_CURRENTAVG),
-        SEARCHBP_SHARD_STATS_RESOURCE_ELASPEDTIME_USAGE_CANCELLATIONCOUNT(
+                        .SEARCHBP_SHARD_TASK_STATS_RESOURCE_CPU_USAGE_CANCELLATION_COUNT),
+        SEARCHBP_SHARD_TASK_STATS_RESOURCE_CPU_USAGE_CURRENT_MAX(
                 SearchBackPressureStatsValue.Constants
-                        .SEARCHBP_SHARD_STATS_RESOURCE_ELASPEDTIME_USAGE_CANCELLATIONCOUNT),
-        SEARCHBP_SHARD_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENTMAX(
+                        .SEARCHBP_SHARD_TASK_STATS_RESOURCE_CPU_USAGE_CURRENT_MAX),
+        SEARCHBP_SHARD_TASK_STATS_RESOURCE_CPU_USAGE_CURRENT_AVG(
                 SearchBackPressureStatsValue.Constants
-                        .SEARCHBP_SHARD_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENTMAX),
-        SEARCHBP_SHARD_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENTAVG(
+                        .SEARCHBP_SHARD_TASK_STATS_RESOURCE_CPU_USAGE_CURRENT_AVG),
+        SEARCHBP_SHARD_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CANCELLATION_COUNT(
                 SearchBackPressureStatsValue.Constants
-                        .SEARCHBP_SHARD_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENTAVG),
-        SEARCHBP_TASK_STATS_CANCELLATIONCOUNT(
-                SearchBackPressureStatsValue.Constants.SEARCHBP_TASK_STATS_CANCELLATIONCOUNT),
-        SEARCHBP_TASK_STATS_LIMITREACHEDCOUNT(
-                SearchBackPressureStatsValue.Constants.SEARCHBP_TASK_STATS_LIMITREACHEDCOUNT),
-        SEARCHBP_TASK_STATS_COMPLETIONCOUNT(Constants.SEARCHBP_TASK_STATS_COMPLETIONCOUNT),
-        SEARCHBP_TASK_STATS_RESOURCE_HEAP_USAGE_CANCELLATIONCOUNT(
+                        .SEARCHBP_SHARD_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CANCELLATION_COUNT),
+        SEARCHBP_SHARD_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENT_MAX(
                 SearchBackPressureStatsValue.Constants
-                        .SEARCHBP_TASK_STATS_RESOURCE_HEAP_USAGE_CANCELLATIONCOUNT),
-        SEARCHBP_TASK_STATS_RESOURCE_HEAP_USAGE_CURRENTMAX(
+                        .SEARCHBP_SHARD_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENT_MAX),
+        SEARCHBP_SHARD_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENT_AVG(
                 SearchBackPressureStatsValue.Constants
-                        .SEARCHBP_TASK_STATS_RESOURCE_HEAP_USAGE_CURRENTMAX),
-        SEARCHBP_TASK_STATS_RESOURCE_HEAP_USAGE_ROLLINGAVG(
+                        .SEARCHBP_SHARD_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENT_AVG),
+        SEARCHBP_SEARCH_TASK_STATS_CANCELLATION_COUNT(
                 SearchBackPressureStatsValue.Constants
-                        .SEARCHBP_TASK_STATS_RESOURCE_HEAP_USAGE_ROLLINGAVG),
-        SEARCHBP_TASK_STATS_RESOURCE_CPU_USAGE_CANCELLATIONCOUNT(
+                        .SEARCHBP_SEARCH_TASK_STATS_CANCELLATION_COUNT),
+        SEARCHBP_SEARCH_TASK_STATS_LIMIT_REACHED_COUNT(
                 SearchBackPressureStatsValue.Constants
-                        .SEARCHBP_TASK_STATS_RESOURCE_CPU_USAGE_CANCELLATIONCOUNT),
-        SEARCHBP_TASK_STATS_RESOURCE_CPU_USAGE_CURRENTMAX(
+                        .SEARCHBP_SEARCH_TASK_STATS_LIMIT_REACHED_COUNT),
+        SEARCHBP_SEARCH_TASK_STATS_COMPLETION_COUNT(
+                Constants.SEARCHBP_SEARCH_TASK_STATS_COMPLETION_COUNT),
+        SEARCHBP_SEARCH_TASK_STATS_RESOURCE_HEAP_USAGE_CANCELLATION_COUNT(
                 SearchBackPressureStatsValue.Constants
-                        .SEARCHBP_TASK_STATS_RESOURCE_CPU_USAGE_CURRENTMAX),
-        SEARCHBP_TASK_STATS_RESOURCE_CPU_USAGE_CURRENTAVG(
+                        .SEARCHBP_SEARCH_TASK_STATS_RESOURCE_HEAP_USAGE_CANCELLATION_COUNT),
+        SEARCHBP_SEARCH_TASK_STATS_RESOURCE_HEAP_USAGE_CURRENT_MAX(
                 SearchBackPressureStatsValue.Constants
-                        .SEARCHBP_TASK_STATS_RESOURCE_CPU_USAGE_CURRENTAVG),
-        SEARCHBP_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CANCELLATIONCOUNT(
+                        .SEARCHBP_SEARCH_TASK_STATS_RESOURCE_HEAP_USAGE_CURRENT_MAX),
+        SEARCHBP_SEARCH_TASK_STATS_RESOURCE_HEAP_USAGE_ROLLING_AVG(
                 SearchBackPressureStatsValue.Constants
-                        .SEARCHBP_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CANCELLATIONCOUNT),
-        SEARCHBP_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENTMAX(
+                        .SEARCHBP_SEARCH_TASK_STATS_RESOURCE_HEAP_USAGE_ROLLING_AVG),
+        SEARCHBP_SEARCH_TASK_STATS_RESOURCE_CPU_USAGE_CANCELLATION_COUNT(
                 SearchBackPressureStatsValue.Constants
-                        .SEARCHBP_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENTMAX),
-        SEARCHBP_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENTAVG(
+                        .SEARCHBP_SEARCH_TASK_STATS_RESOURCE_CPU_USAGE_CANCELLATION_COUNT),
+        SEARCHBP_SEARCH_TASK_STATS_RESOURCE_CPU_USAGE_CURRENT_MAX(
                 SearchBackPressureStatsValue.Constants
-                        .SEARCHBP_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENTAVG),
+                        .SEARCHBP_SEARCH_TASK_STATS_RESOURCE_CPU_USAGE_CURRENT_MAX),
+        SEARCHBP_SEARCH_TASK_STATS_RESOURCE_CPU_USAGE_CURRENT_AVG(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_SEARCH_TASK_STATS_RESOURCE_CPU_USAGE_CURRENT_AVG),
+        SEARCHBP_SEARCH_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CANCELLATION_COUNT(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_SEARCH_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CANCELLATION_COUNT),
+        SEARCHBP_SEARCH_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENT_MAX(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_SEARCH_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENT_MAX),
+        SEARCHBP_SEARCH_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENT_AVG(
+                SearchBackPressureStatsValue.Constants
+                        .SEARCHBP_SEARCH_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENT_AVG),
         SEARCHBP_RESOURCE_USAGE_TRACKER_STATS_CANCELLATIONCOUNT(
                 SearchBackPressureStatsValue.Constants
                         .SEARCHBP_RESOURCE_USAGE_TRACKER_STATS_CANCELLATIONCOUNT),
@@ -922,7 +928,7 @@ public class AllMetrics {
                         .SEARCHBP_RESOURCE_USAGE_TRACKER_STATS_FRAGMENT),
         SEARCHBP_SEARCH_TASK_STATS_CANCELLATIONCOUNT(
                 SearchBackPressureStatsValue.Constants
-                        .SEARCHBP_SEARCH_TASK_STATS_CANCELLATIONCOUNT),
+                        .SEARCHBP_SEARCH_TASK_STATS_CANCELLATION_COUNT),
         SEARCHBP_SEARCH_TASK_STATS_LIMITREACHEDCOUNT(
                 SearchBackPressureStatsValue.Constants
                         .SEARCHBP_SEARCH_TASK_STATS_LIMITREACHEDCOUNT),
@@ -964,56 +970,64 @@ public class AllMetrics {
             // SearchBackPressure Metrics
             public static final String SEARCHBP_MODE = "searchbp_mode";
             public static final String SEARCHBP_NODEID = "searchbp_nodeid";
-            public static final String SEARCHBP_SHARD_STATS_CANCELLATIONCOUNT =
-                    "searchbp_shard_stats_cancellationCount";
-            public static final String SEARCHBP_SHARD_STATS_LIMITREACHEDCOUNT =
-                    "searchbp_shard_stats_limitReachedCount";
-            public static final String SEARCHBP_SHARD_STATS_COMPLETIONCOUNT =
-                    "searchbp_shard_stats_completionCount";
-            public static final String SEARCHBP_SHARD_STATS_RESOURCE_HEAP_USAGE_CANCELLATIONCOUNT =
-                    "searchbp_shard_stats_resource_heap_usage_cancellationCount";
-            public static final String SEARCHBP_SHARD_STATS_RESOURCE_HEAP_USAGE_CURRENTMAX =
-                    "searchbp_shard_stats_resource_heap_usage_currentMax";
-            public static final String SEARCHBP_SHARD_STATS_RESOURCE_HEAP_USAGE_ROLLINGAVG =
-                    "searchbp_shard_stats_resource_heap_usage_rollingAvg";
-            public static final String SEARCHBP_SHARD_STATS_RESOURCE_CPU_USAGE_CANCELLATIONCOUNT =
-                    "searchbp_shard_stats_resource_cpu_usage_cancellationCount";
-            public static final String SEARCHBP_SHARD_STATS_RESOURCE_CPU_USAGE_CURRENTMAX =
-                    "searchbp_shard_stats_resource_cpu_usage_currentMax";
-            public static final String SEARCHBP_SHARD_STATS_RESOURCE_CPU_USAGE_CURRENTAVG =
-                    "searchbp_shard_stats_resource_cpu_usage_currentAvg";
+            public static final String SEARCHBP_SHARD_TASK_STATS_CANCELLATION_COUNT =
+                    "searchbp_shard_task_stats_cancellationCount";
+            public static final String SEARCHBP_SHARD_TASK_STATS_LIMIT_REACHED_COUNT =
+                    "searchbp_shard_task_stats_limitReachedCount";
+            public static final String SEARCHBP_SHARD_TASK_STATS_COMPLETION_COUNT =
+                    "searchbp_shard_task_stats_completionCount";
             public static final String
-                    SEARCHBP_SHARD_STATS_RESOURCE_ELASPEDTIME_USAGE_CANCELLATIONCOUNT =
-                            "searchbp_shard_stats_resource_elaspedtime_usage_cancellationCount";
-            public static final String SEARCHBP_SHARD_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENTMAX =
-                    "searchbp_shard_stats_resource_elaspedtime_usage_currentMax";
-            public static final String SEARCHBP_SHARD_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENTAVG =
-                    "searchbp_shard_stats_resource_elaspedtime_usage_currentAvg";
-            public static final String SEARCHBP_TASK_STATS_CANCELLATIONCOUNT =
-                    "searchbp_task_stats_cancellationCount";
-            public static final String SEARCHBP_TASK_STATS_LIMITREACHEDCOUNT =
-                    "searchbp_task_stats_limitReachedCount";
-            public static final String SEARCHBP_TASK_STATS_COMPLETIONCOUNT =
-                    "searchbp_task_stats_completionCount";
-            public static final String SEARCHBP_TASK_STATS_RESOURCE_HEAP_USAGE_CANCELLATIONCOUNT =
-                    "searchbp_task_stats_resource_heap_usage_cancellationCount";
-            public static final String SEARCHBP_TASK_STATS_RESOURCE_HEAP_USAGE_CURRENTMAX =
-                    "searchbp_task_stats_resource_heap_usage_currentMax";
-            public static final String SEARCHBP_TASK_STATS_RESOURCE_HEAP_USAGE_ROLLINGAVG =
-                    "searchbp_task_stats_resource_heap_usage_rollingAvg";
-            public static final String SEARCHBP_TASK_STATS_RESOURCE_CPU_USAGE_CANCELLATIONCOUNT =
-                    "searchbp_task_stats_resource_cpu_usage_cancellationCount";
-            public static final String SEARCHBP_TASK_STATS_RESOURCE_CPU_USAGE_CURRENTMAX =
-                    "searchbp_task_stats_resource_cpu_usage_currentMax";
-            public static final String SEARCHBP_TASK_STATS_RESOURCE_CPU_USAGE_CURRENTAVG =
-                    "searchbp_task_stats_resource_cpu_usage_currentAvg";
+                    SEARCHBP_SHARD_TASK_STATS_RESOURCE_HEAP_USAGE_CANCELLATION_COUNT =
+                            "searchbp_shard_task_stats_resource_heap_usage_cancellationCount";
+            public static final String SEARCHBP_SHARD_TASK_STATS_RESOURCE_HEAP_USAGE_CURRENT_MAX =
+                    "searchbp_shard_task_stats_resource_heap_usage_currentMax";
+            public static final String SEARCHBP_SHARD_TASK_STATS_RESOURCE_HEAP_USAGE_ROLLING_AVG =
+                    "searchbp_shard_task_stats_resource_heap_usage_rollingAvg";
             public static final String
-                    SEARCHBP_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CANCELLATIONCOUNT =
-                            "searchbp_task_stats_resource_elaspedtime_usage_cancellationCount";
-            public static final String SEARCHBP_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENTMAX =
-                    "searchbp_task_stats_resource_elaspedtime_usage_currentMax";
-            public static final String SEARCHBP_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENTAVG =
-                    "searchbp_task_stats_resource_elaspedtime_usage_currentAvg";
+                    SEARCHBP_SHARD_TASK_STATS_RESOURCE_CPU_USAGE_CANCELLATION_COUNT =
+                            "searchbp_shard_task_stats_resource_cpu_usage_cancellationCount";
+            public static final String SEARCHBP_SHARD_TASK_STATS_RESOURCE_CPU_USAGE_CURRENT_MAX =
+                    "searchbp_shard_task_stats_resource_cpu_usage_currentMax";
+            public static final String SEARCHBP_SHARD_TASK_STATS_RESOURCE_CPU_USAGE_CURRENT_AVG =
+                    "searchbp_shard_task_stats_resource_cpu_usage_currentAvg";
+            public static final String
+                    SEARCHBP_SHARD_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CANCELLATION_COUNT =
+                            "searchbp_shard_task_stats_resource_elaspedtime_usage_cancellationCount";
+            public static final String
+                    SEARCHBP_SHARD_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENT_MAX =
+                            "searchbp_shard_task_stats_resource_elaspedtime_usage_currentMax";
+            public static final String
+                    SEARCHBP_SHARD_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENT_AVG =
+                            "searchbp_shard_task_stats_resource_elaspedtime_usage_currentAvg";
+            public static final String SEARCHBP_SEARCH_TASK_STATS_CANCELLATION_COUNT =
+                    "searchbp_search_task_stats_cancellationCount";
+            public static final String SEARCHBP_SEARCH_TASK_STATS_LIMIT_REACHED_COUNT =
+                    "searchbp_search_task_stats_limitReachedCount";
+            public static final String SEARCHBP_SEARCH_TASK_STATS_COMPLETION_COUNT =
+                    "searchbp_search_task_stats_completionCount";
+            public static final String
+                    SEARCHBP_SEARCH_TASK_STATS_RESOURCE_HEAP_USAGE_CANCELLATION_COUNT =
+                            "searchbp_search_task_stats_resource_heap_usage_cancellationCount";
+            public static final String SEARCHBP_SEARCH_TASK_STATS_RESOURCE_HEAP_USAGE_CURRENT_MAX =
+                    "searchbp_search_task_stats_resource_heap_usage_currentMax";
+            public static final String SEARCHBP_SEARCH_TASK_STATS_RESOURCE_HEAP_USAGE_ROLLING_AVG =
+                    "searchbp_search_task_stats_resource_heap_usage_rollingAvg";
+            public static final String
+                    SEARCHBP_SEARCH_TASK_STATS_RESOURCE_CPU_USAGE_CANCELLATION_COUNT =
+                            "searchbp_search_task_stats_resource_cpu_usage_cancellationCount";
+            public static final String SEARCHBP_SEARCH_TASK_STATS_RESOURCE_CPU_USAGE_CURRENT_MAX =
+                    "searchbp_search_task_stats_resource_cpu_usage_currentMax";
+            public static final String SEARCHBP_SEARCH_TASK_STATS_RESOURCE_CPU_USAGE_CURRENT_AVG =
+                    "searchbp_search_task_stats_resource_cpu_usage_currentAvg";
+            public static final String
+                    SEARCHBP_SEARCH_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CANCELLATION_COUNT =
+                            "searchbp_search_task_stats_resource_elaspedtime_usage_cancellationCount";
+            public static final String
+                    SEARCHBP_SEARCH_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENT_MAX =
+                            "searchbp_search_task_stats_resource_elaspedtime_usage_currentMax";
+            public static final String
+                    SEARCHBP_SEARCH_TASK_STATS_RESOURCE_ELASPEDTIME_USAGE_CURRENT_AVG =
+                            "searchbp_search_task_stats_resource_elaspedtime_usage_currentAvg";
             // ResourceUsageTrackerStats
             public static final String SEARCHBP_RESOURCE_USAGE_TRACKER_STATS_CANCELLATIONCOUNT =
                     "cancellationCount";

--- a/src/main/java/org/opensearch/performanceanalyzer/commons/metrics/AllMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/commons/metrics/AllMetrics.java
@@ -845,6 +845,7 @@ public class AllMetrics {
                 SearchBackPressureStatsValue.Constants.SEARCHBP_SHARD_STATS_CANCELLATIONCOUNT),
         SEARCHBP_SHARD_STATS_LIMITREACHEDCOUNT(
                 SearchBackPressureStatsValue.Constants.SEARCHBP_SHARD_STATS_LIMITREACHEDCOUNT),
+        SEARCHBP_SHARD_STATS_COMPLETIONCOUNT(Constants.SEARCHBP_SHARD_STATS_COMPLETIONCOUNT),
         SEARCHBP_SHARD_STATS_RESOURCE_HEAP_USAGE_CANCELLATIONCOUNT(
                 SearchBackPressureStatsValue.Constants
                         .SEARCHBP_SHARD_STATS_RESOURCE_HEAP_USAGE_CANCELLATIONCOUNT),
@@ -876,6 +877,7 @@ public class AllMetrics {
                 SearchBackPressureStatsValue.Constants.SEARCHBP_TASK_STATS_CANCELLATIONCOUNT),
         SEARCHBP_TASK_STATS_LIMITREACHEDCOUNT(
                 SearchBackPressureStatsValue.Constants.SEARCHBP_TASK_STATS_LIMITREACHEDCOUNT),
+        SEARCHBP_TASK_STATS_COMPLETIONCOUNT(Constants.SEARCHBP_TASK_STATS_COMPLETIONCOUNT),
         SEARCHBP_TASK_STATS_RESOURCE_HEAP_USAGE_CANCELLATIONCOUNT(
                 SearchBackPressureStatsValue.Constants
                         .SEARCHBP_TASK_STATS_RESOURCE_HEAP_USAGE_CANCELLATIONCOUNT),
@@ -966,6 +968,8 @@ public class AllMetrics {
                     "searchbp_shard_stats_cancellationCount";
             public static final String SEARCHBP_SHARD_STATS_LIMITREACHEDCOUNT =
                     "searchbp_shard_stats_limitReachedCount";
+            public static final String SEARCHBP_SHARD_STATS_COMPLETIONCOUNT =
+                    "searchbp_shard_stats_completionCount";
             public static final String SEARCHBP_SHARD_STATS_RESOURCE_HEAP_USAGE_CANCELLATIONCOUNT =
                     "searchbp_shard_stats_resource_heap_usage_cancellationCount";
             public static final String SEARCHBP_SHARD_STATS_RESOURCE_HEAP_USAGE_CURRENTMAX =
@@ -989,6 +993,8 @@ public class AllMetrics {
                     "searchbp_task_stats_cancellationCount";
             public static final String SEARCHBP_TASK_STATS_LIMITREACHEDCOUNT =
                     "searchbp_task_stats_limitReachedCount";
+            public static final String SEARCHBP_TASK_STATS_COMPLETIONCOUNT =
+                    "searchbp_task_stats_completionCount";
             public static final String SEARCHBP_TASK_STATS_RESOURCE_HEAP_USAGE_CANCELLATIONCOUNT =
                     "searchbp_task_stats_resource_heap_usage_cancellationCount";
             public static final String SEARCHBP_TASK_STATS_RESOURCE_HEAP_USAGE_CURRENTMAX =
@@ -1023,6 +1029,8 @@ public class AllMetrics {
                     "cancellationCount";
             public static final String SEARCHBP_SEARCH_TASK_STATS_LIMITREACHEDCOUNT =
                     "limitReachedCount";
+            public static final String SEARCHBP_SEARCH_TASK_STATS_COMPLETIONCOUNT =
+                    "completionCount";
             public static final String SEARCHBP_SEARCH_TASK_STATS_RESOURCE_USAGE_TRACKER_STATS =
                     "resourceUsageTrackerStats";
             // SearchShardTaskStats
@@ -1030,6 +1038,8 @@ public class AllMetrics {
                     "cancellationCount";
             public static final String SEARCHBP_SEARCH_SHARD_TASK_STATS_LIMITREACHEDCOUNT =
                     "limitReachedCount";
+            public static final String SEARCHBP_SEARCH_SHARD_TASK_STATS_COMPLETIONCOUNT =
+                    "completionCount";
             public static final String
                     SEARCHBP_SEARCH_SHARD_TASK_STATS_RESOURCE_USAGE_TRACKER_STATS =
                             "resourceUsageTrackerStats";

--- a/src/main/java/org/opensearch/performanceanalyzer/commons/stats/metrics/StatExceptionCode.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/commons/stats/metrics/StatExceptionCode.java
@@ -82,7 +82,8 @@ public enum StatExceptionCode {
     CACHE_CONFIG_METRICS_COLLECTOR_ERROR("CacheConfigMetricsCollectorError"),
     ADMISSION_CONTROL_COLLECTOR_ERROR("AdmissionControlCollectorError"),
     CIRCUIT_BREAKER_COLLECTOR_ERROR("CircuitBreakerCollectorError"),
-    CLUSTER_MANAGER_SERVICE_EVENTS_METRICS_COLLECTOR_ERROR("ClusterManagerServiceEventsMetricsCollectorError"),
+    CLUSTER_MANAGER_SERVICE_EVENTS_METRICS_COLLECTOR_ERROR(
+            "ClusterManagerServiceEventsMetricsCollectorError"),
     CLUSTER_MANAGER_SERVICE_METRICS_COLLECTOR_ERROR("ClusterManagerServiceMetricsCollectorError"),
     CLUSTER_MANAGER_THROTTLING_COLLECTOR_ERROR("ClusterManagerThrottlingMetricsCollectorError"),
     FAULT_DETECTION_COLLECTOR_ERROR("FaultDetectionMetricsCollectorError"),


### PR DESCRIPTION
Adding `completionCount` metrics constants. This was previously not part of `/stats/search_backpressure` API as the change got merged post 2.11 release. We will need this metric to find correct cancellation percentage with respect to total completed tasks at shard and co-ordinator level.

Github issue: https://github.com/opensearch-project/performance-analyzer/issues/587

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

**Describe the solution you are proposing**
A clear and concise description of what you want to happen.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
