### PR TITLE
test: add ThreadCPUTests

### DIFF
--- a/src/test/java/org/opensearch/performanceanalyzer/commons/os/OSTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/commons/os/OSTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.performanceanalyzer.commons.os;
+
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.stream.Collectors;
+
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore("javax.management.*")
+@SuppressStaticInitializationFor({"org.opensearch.performanceanalyzer.commons.os.OSGlobals"})
+// whenNew requires the class calling the constructor to be PreparedForTest
+@PrepareForTest({SchemaFileParser.class, OSGlobals.class})
+public abstract class OSTests {
+    Map<String, Map<String, Object>> tidKVMap;
+    Map<String, Map<String, Object>> nextTidKVMap;
+
+    public OSTests(SortedMap<String, Map<String, Object>> tidKVMap, SortedMap<String, Map<String, Object>> nextTidKVMap, String pid, List<String> tids, long scClkTlk, long millisStart, long millisEnd) throws Exception {
+        // mock OSGlobals
+        PowerMockito.mockStatic(OSGlobals.class);
+        PowerMockito.when(OSGlobals.getPid()).thenReturn(pid);
+        PowerMockito.when(OSGlobals.getTids()).thenReturn(tids);
+        PowerMockito.when(OSGlobals.getScClkTck()).thenReturn(scClkTlk);
+
+        // mock System.currentTimeMillis()
+        // used by ThreadSched to compute SchedMetric
+        PowerMockito.mockStatic(System.class);
+        // having the time difference = 1000ms
+        // means that contextSwitchRate = difference in totctxsws
+        PowerMockito.when(System.currentTimeMillis()).thenReturn(millisStart, millisEnd);
+
+        // mock SchemaFileParser (used by ThreadSched to read procfiles)
+        SchemaFileParser schemaFileParser = Mockito.mock(SchemaFileParser.class);
+
+        // create an array that contains all the values of tidKVMap
+        Object[] tidArr = tidKVMap.values().toArray();
+        Object[] nextTidArr = nextTidKVMap.values().toArray();
+
+        PowerMockito.when(schemaFileParser.parse())
+                .thenReturn((Map<String, Object>) tidArr[0], (Map<String, Object>[]) Arrays.copyOfRange(tidArr, 1, nextTidArr.length))
+                .thenReturn((Map<String, Object>) nextTidArr[0], (Map<String, Object>[]) Arrays.copyOfRange(nextTidArr, 1, nextTidArr.length));
+
+        PowerMockito.whenNew(SchemaFileParser.class)
+                .withAnyArguments()
+                .thenReturn(schemaFileParser);
+    }
+}

--- a/src/test/java/org/opensearch/performanceanalyzer/commons/os/ThreadCPUTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/commons/os/ThreadCPUTests.java
@@ -34,26 +34,18 @@ public class ThreadCPUTests extends OSTests {
                                                 "stime", 1L, "rss", 1L),
                                 "2",
                                         Map.of(
-                                                "pid", 2, "minflt", 1L, "majflt", 1L, "utime", 1L,
-                                                "stime", 1L, "rss", 1L),
-                                "3",
-                                        Map.of(
-                                                "pid", 3, "minflt", 1L, "majflt", 1L, "utime", 1L,
-                                                "stime", 1L, "rss", 1L))),
+                                                "pid", 2, "minflt", 5L, "majflt", 10L, "utime", 3L,
+                                                "stime", 13L, "rss", 1L))),
                 new TreeMap<String, Map<String, Object>>(
                         Map.of(
                                 "1",
                                         Map.of(
-                                                "pid", 1, "minflt", 10L, "majflt", 100L, "utime", 1L,
-                                                "stime", 1L, "rss", 1L),
+                                                "pid", 1, "minflt", 10L, "majflt", 100L, "utime",
+                                                6L, "stime", 6L, "rss", 2L),
                                 "2",
                                         Map.of(
-                                                "pid", 2, "minflt", 1L, "majflt", 1L, "utime", 1L,
-                                                "stime", 1L, "rss", 1L),
-                                "3",
-                                        Map.of(
-                                                "pid", 3, "minflt", 1L, "majflt", 1L, "utime", 1L,
-                                                "stime", 1L, "rss", 1L))),
+                                                "pid", 2, "minflt", 10L, "majflt", 15L, "utime",
+                                                13L, "stime", 18L, "rss", 4L))),
                 "0",
                 List.of("1", "2", "3"),
                 100,
@@ -85,17 +77,14 @@ public class ThreadCPUTests extends OSTests {
                         isA(String[].class),
                         isA(SchemaFileParser.FieldTypes[].class),
                         eq(true));
-        PowerMockito.verifyNew(SchemaFileParser.class)
-                .withArguments(
-                        eq("/proc/0/task/3/stat"),
-                        isA(String[].class),
-                        isA(SchemaFileParser.FieldTypes[].class),
-                        eq(true));
 
         ThreadCPU.INSTANCE.addSample();
 
-        verify(linuxCPUPagingActivityGenerator).setCPUUtilization("1", 1.0);
-        verify(linuxCPUPagingActivityGenerator).setCPUUtilization("2", 2.0);
-        verify(linuxCPUPagingActivityGenerator).setCPUUtilization("3", 3.0);
+        verify(linuxCPUPagingActivityGenerator)
+                .setPagingActivities("1", new Double[] {14.0, 9.0, 4.0});
+        verify(linuxCPUPagingActivityGenerator).setCPUUtilization("1", 0.29);
+        verify(linuxCPUPagingActivityGenerator)
+                .setPagingActivities("2", new Double[] {5.0, 5.0, 4.0});
+        verify(linuxCPUPagingActivityGenerator).setCPUUtilization("2", 0.15);
     }
 }

--- a/src/test/java/org/opensearch/performanceanalyzer/commons/os/ThreadCPUTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/commons/os/ThreadCPUTests.java
@@ -5,21 +5,97 @@
 
 package org.opensearch.performanceanalyzer.commons.os;
 
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.verify;
 
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.opensearch.performanceanalyzer.commons.metrics_generator.linux.LinuxCPUPagingActivityGenerator;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
 
-public class ThreadCPUTests {
-    public static void main(String[] args) throws Exception {
-        runOnce();
+@RunWith(PowerMockRunner.class)
+// whenNew requires the class calling the constructor to be PreparedForTest
+@PrepareForTest({SchemaFileParser.class, OSGlobals.class, ThreadCPU.class})
+public class ThreadCPUTests extends OSTests {
+    public ThreadCPUTests() throws Exception {
+        super(
+                new TreeMap<String, Map<String, Object>>(
+                        Map.of(
+                                "1",
+                                        Map.of(
+                                                "pid", 1, "minflt", 1L, "majflt", 1L, "utime", 1L,
+                                                "stime", 1L, "rss", 1L),
+                                "2",
+                                        Map.of(
+                                                "pid", 2, "minflt", 1L, "majflt", 1L, "utime", 1L,
+                                                "stime", 1L, "rss", 1L),
+                                "3",
+                                        Map.of(
+                                                "pid", 3, "minflt", 1L, "majflt", 1L, "utime", 1L,
+                                                "stime", 1L, "rss", 1L))),
+                new TreeMap<String, Map<String, Object>>(
+                        Map.of(
+                                "1",
+                                        Map.of(
+                                                "pid", 1, "minflt", 10L, "majflt", 100L, "utime", 1L,
+                                                "stime", 1L, "rss", 1L),
+                                "2",
+                                        Map.of(
+                                                "pid", 2, "minflt", 1L, "majflt", 1L, "utime", 1L,
+                                                "stime", 1L, "rss", 1L),
+                                "3",
+                                        Map.of(
+                                                "pid", 3, "minflt", 1L, "majflt", 1L, "utime", 1L,
+                                                "stime", 1L, "rss", 1L))),
+                "0",
+                List.of("1", "2", "3"),
+                100,
+                10,
+                1010);
+
+        mockSchemaFileParser();
     }
 
-    private static void runOnce() {
-        ThreadCPU.INSTANCE.addSample();
-        System.out.println(
-                "cpumap and pagemap:" + ThreadCPU.INSTANCE.getCPUPagingActivity().toString());
-    }
-
-    // - to enhance
     @Test
-    public void testMetrics() {}
+    public void testMetrics() throws Exception {
+        LinuxCPUPagingActivityGenerator linuxCPUPagingActivityGenerator =
+                Mockito.mock(LinuxCPUPagingActivityGenerator.class);
+        PowerMockito.whenNew(LinuxCPUPagingActivityGenerator.class)
+                .withNoArguments()
+                .thenReturn(linuxCPUPagingActivityGenerator);
+
+        ThreadCPU.INSTANCE.addSample();
+
+        PowerMockito.verifyNew(SchemaFileParser.class)
+                .withArguments(
+                        eq("/proc/0/task/1/stat"),
+                        isA(String[].class),
+                        isA(SchemaFileParser.FieldTypes[].class),
+                        eq(true));
+        PowerMockito.verifyNew(SchemaFileParser.class)
+                .withArguments(
+                        eq("/proc/0/task/2/stat"),
+                        isA(String[].class),
+                        isA(SchemaFileParser.FieldTypes[].class),
+                        eq(true));
+        PowerMockito.verifyNew(SchemaFileParser.class)
+                .withArguments(
+                        eq("/proc/0/task/3/stat"),
+                        isA(String[].class),
+                        isA(SchemaFileParser.FieldTypes[].class),
+                        eq(true));
+
+        ThreadCPU.INSTANCE.addSample();
+
+        verify(linuxCPUPagingActivityGenerator).setCPUUtilization("1", 1.0);
+        verify(linuxCPUPagingActivityGenerator).setCPUUtilization("2", 2.0);
+        verify(linuxCPUPagingActivityGenerator).setCPUUtilization("3", 3.0);
+    }
 }

--- a/src/test/java/org/opensearch/performanceanalyzer/commons/os/ThreadDiskIOTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/commons/os/ThreadDiskIOTests.java
@@ -5,70 +5,20 @@
 
 package org.opensearch.performanceanalyzer.commons.os;
 
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.opensearch.performanceanalyzer.commons.metrics_generator.linux.LinuxDiskIOMetricsGenerator;
-import org.opensearch.performanceanalyzer.commons.metrics_generator.linux.LinuxSchedMetricsGenerator;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.junit.Test;
 
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore("javax.management.*")
-@SuppressStaticInitializationFor({ "org.opensearch.performanceanalyzer.commons.os.OSGlobals" })
-// whenNew requires the class calling the constructor to be PreparedForTest
-@PrepareForTest({ SchemaFileParser.class, OSGlobals.class, ThreadDiskIO.class })
-public class ThreadDiskIOTests extends OSTests {
-	public ThreadDiskIOTests() throws Exception {
-		super(
-				new TreeMap<String, Map<String, Object>>(Map.of(
-					"1", Map.of("runticks", 200000000L, "waitticks", 200000000L, "totctxsws", 200L),
-					"2", Map.of("runticks", 500000000L, "waitticks", 500000000L, "totctxsws", 20L),
-					"3",
-					Map.of(
-							"runticks",
-							700000000L,
-							"waitticks",
-							700000000L,
-							"totctxsws",
-							220L))),
-				new TreeMap<String, Map<String, Object>>(Map.of(
-						"1",
-						Map.of("runticks", 200000000L, "waitticks", 200000000L, "totctxsws",
-								200L),
-						"2",
-						Map.of("runticks", 500000000L, "waitticks", 500000000L, "totctxsws",
-								20L),
-						"3",
-						Map.of(
-								"runticks",
-								700000000L,
-								"waitticks",
-								700000000L,
-								"totctxsws",
-								220L))),
-				"0", List.of("1", "2", "3"), 100, 10, 1010);
-	}
+public class ThreadDiskIOTests {
+    public static void main(String[] args) throws Exception {
+        runOnce();
+    }
 
-	@Test
-	public void testMetrics() throws Exception {
-		// this test checks that
-		// 1. ThreadDiskIO calls the SchemaFileParser constructor with the correct path
-		// 2. ThreadDiskIO calculates the correct metrics from procfile data
+    public static void runOnce() {
+        ThreadDiskIO.addSample();
+        System.out.println(ThreadDiskIO.getIOUtilization().toString());
+    }
 
-		// mock the metrics generator used by DiskIO
-		LinuxDiskIOMetricsGenerator linuxDiskIOMetricsGenerator = Mockito
-				.mock(LinuxDiskIOMetricsGenerator.class);
-		PowerMockito.whenNew(LinuxDiskIOMetricsGenerator.class)
-				.withNoArguments()
-				.thenReturn(linuxDiskIOMetricsGenerator);
-	}
+    // - to enhance
+    @Test
+    public void testMetrics() {}
 }

--- a/src/test/java/org/opensearch/performanceanalyzer/commons/os/ThreadDiskIOTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/commons/os/ThreadDiskIOTests.java
@@ -9,16 +9,16 @@ package org.opensearch.performanceanalyzer.commons.os;
 import org.junit.Test;
 
 public class ThreadDiskIOTests {
-    public static void main(String[] args) throws Exception {
-        runOnce();
-    }
 
     public static void runOnce() {
         ThreadDiskIO.addSample();
         System.out.println(ThreadDiskIO.getIOUtilization().toString());
     }
 
-    // - to enhance
     @Test
-    public void testMetrics() {}
+    public void testMetrics() {
+        // this test checks that
+        // 1. ThreadDiskIO calls the SchemaFileParser constructor with the correct path
+        // 2. ThreadDiskIO calculates the correct metrics from procfile data
+    }
 }

--- a/src/test/java/org/opensearch/performanceanalyzer/commons/os/ThreadDiskIOTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/commons/os/ThreadDiskIOTests.java
@@ -4,10 +4,25 @@
  */
 
 package org.opensearch.performanceanalyzer.commons.os;
-
+import java.util.List;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.opensearch.performanceanalyzer.commons.metrics_generator.linux.LinuxDiskIOMetricsGenerator;
+import org.opensearch.performanceanalyzer.commons.metrics_generator.linux.LinuxSchedMetricsGenerator;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.junit.Test;
 
+@RunWith(PowerMockRunner.class)
+@PowerMockIgnore("javax.management.*")
+@SuppressStaticInitializationFor({"org.opensearch.performanceanalyzer.commons.os.OSGlobals"})
+// whenNew requires the class calling the constructor to be PreparedForTest
+@PrepareForTest({SchemaFileParser.class, OSGlobals.class, ThreadDiskIO.class})
 public class ThreadDiskIOTests {
 
     public static void runOnce() {
@@ -16,9 +31,31 @@ public class ThreadDiskIOTests {
     }
 
     @Test
-    public void testMetrics() {
+    public void testMetrics() throws Exception {
         // this test checks that
         // 1. ThreadDiskIO calls the SchemaFileParser constructor with the correct path
         // 2. ThreadDiskIO calculates the correct metrics from procfile data
+
+        // mock OSGlobals
+        PowerMockito.mockStatic(OSGlobals.class);
+        PowerMockito.when(OSGlobals.getPid()).thenReturn("0");
+        PowerMockito.when(OSGlobals.getTids()).thenReturn(List.of("1", "2", "3"));
+
+        // mock System.currentTimeMillis()
+        // used by DiskIO to compute SchedMetric
+        PowerMockito.mockStatic(System.class);
+        // having the time difference = 1000ms
+        // means that contextSwitchRate = difference in totctxsws
+        PowerMockito.when(System.currentTimeMillis()).thenReturn(10L, 1010L);
+
+        // mock the metrics generator used by DiskIO
+        LinuxDiskIOMetricsGenerator linuxDiskIOMetricsGenerator =
+                Mockito.mock(LinuxDiskIOMetricsGenerator.class);
+        PowerMockito.whenNew(LinuxDiskIOMetricsGenerator.class)
+                .withNoArguments()
+                .thenReturn(linuxDiskIOMetricsGenerator);
+
+        // mock SchemaFileParser (used by ThreadSched to read procfiles)
+        SchemaFileParser schemaFileParser = Mockito.mock(SchemaFileParser.class);
     }
 }

--- a/src/test/java/org/opensearch/performanceanalyzer/commons/os/ThreadSchedTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/commons/os/ThreadSchedTests.java
@@ -12,48 +12,81 @@ import static org.mockito.Mockito.verify;
 
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.opensearch.performanceanalyzer.commons.metrics_generator.linux.LinuxSchedMetricsGenerator;
 import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 @RunWith(PowerMockRunner.class)
-@PowerMockIgnore("javax.management.*")
-@SuppressStaticInitializationFor({"org.opensearch.performanceanalyzer.commons.os.OSGlobals"})
 // whenNew requires the class calling the constructor to be PreparedForTest
 @PrepareForTest({SchemaFileParser.class, OSGlobals.class, ThreadSched.class})
-public class ThreadSchedTests {
+public class ThreadSchedTests extends OSTests {
+    public ThreadSchedTests() throws Exception {
+        super(
+                new TreeMap<String, Map<String, Object>>(
+                        Map.of(
+                                "1",
+                                Map.of(
+                                        "runticks",
+                                        100000000L,
+                                        "waitticks",
+                                        100000000L,
+                                        "totctxsws",
+                                        100L),
+                                "2",
+                                Map.of(
+                                        "runticks",
+                                        100000000L,
+                                        "waitticks",
+                                        100000000L,
+                                        "totctxsws",
+                                        10L),
+                                "3",
+                                Map.of(
+                                        "runticks",
+                                        500000000L,
+                                        "waitticks",
+                                        500000000L,
+                                        "totctxsws",
+                                        120L))),
+                new TreeMap<String, Map<String, Object>>(
+                        Map.of(
+                                "1",
+                                Map.of(
+                                        "runticks",
+                                        200000000L,
+                                        "waitticks",
+                                        200000000L,
+                                        "totctxsws",
+                                        200L),
+                                "2",
+                                Map.of(
+                                        "runticks",
+                                        500000000L,
+                                        "waitticks",
+                                        500000000L,
+                                        "totctxsws",
+                                        20L),
+                                "3",
+                                Map.of(
+                                        "runticks",
+                                        700000000L,
+                                        "waitticks",
+                                        700000000L,
+                                        "totctxsws",
+                                        220L))),
+                "0",
+                List.of("1", "2", "3"),
+                100,
+                10,
+                1010);
 
-    private Map<String, Map<String, Object>> tidKVMap =
-            Map.of(
-                    "1", Map.of("runticks", 100000000L, "waitticks", 100000000L, "totctxsws", 100L),
-                    "2", Map.of("runticks", 100000000L, "waitticks", 100000000L, "totctxsws", 10L),
-                    "3",
-                            Map.of(
-                                    "runticks",
-                                    500000000L,
-                                    "waitticks",
-                                    500000000L,
-                                    "totctxsws",
-                                    120L));
-
-    private Map<String, Map<String, Object>> nextTidKVMap =
-            Map.of(
-                    "1", Map.of("runticks", 200000000L, "waitticks", 200000000L, "totctxsws", 200L),
-                    "2", Map.of("runticks", 500000000L, "waitticks", 500000000L, "totctxsws", 20L),
-                    "3",
-                            Map.of(
-                                    "runticks",
-                                    700000000L,
-                                    "waitticks",
-                                    700000000L,
-                                    "totctxsws",
-                                    220L));
+        mockSchemaFileParser();
+    }
 
     @Test
     public void testMetrics() throws Exception {
@@ -61,35 +94,12 @@ public class ThreadSchedTests {
         // 1. ThreadSched calls the SchemaFileParser constructor with the correct path
         // 2. ThreadSched calculates the correct metrics from procfile data
 
-        // mock OSGlobals
-        PowerMockito.mockStatic(OSGlobals.class);
-        PowerMockito.when(OSGlobals.getPid()).thenReturn("0");
-        PowerMockito.when(OSGlobals.getTids()).thenReturn(List.of("1", "2", "3"));
-
-        // mock System.currentTimeMillis()
-        // used by ThreadSched to compute SchedMetric
-        PowerMockito.mockStatic(System.class);
-        // having the time difference = 1000ms
-        // means that contextSwitchRate = difference in totctxsws
-        PowerMockito.when(System.currentTimeMillis()).thenReturn(10L, 1010L);
-
         // mock the metrics generator used by ThreadSched
         LinuxSchedMetricsGenerator linuxSchedMetricsGenerator =
                 Mockito.mock(LinuxSchedMetricsGenerator.class);
         PowerMockito.whenNew(LinuxSchedMetricsGenerator.class)
                 .withNoArguments()
                 .thenReturn(linuxSchedMetricsGenerator);
-
-        // mock SchemaFileParser (used by ThreadSched to read procfiles)
-        SchemaFileParser schemaFileParser = Mockito.mock(SchemaFileParser.class);
-
-        PowerMockito.when(schemaFileParser.parse())
-                .thenReturn(tidKVMap.get("1"), tidKVMap.get("2"), tidKVMap.get("3"))
-                .thenReturn(nextTidKVMap.get("1"), nextTidKVMap.get("2"), nextTidKVMap.get("3"));
-
-        PowerMockito.whenNew(SchemaFileParser.class)
-                .withAnyArguments()
-                .thenReturn(schemaFileParser);
 
         ThreadSched.INSTANCE.addSample();
 


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
Add tests for `os/ThreadCPU.java` using `OSTests.java`, a class to abstract over testing classes in `os`. `ThreadSchedTests` is rewritten to use `OSTests.java`.

Follow up to #47 

### Check List
- [X] New functionality includes testing.
  - [X] All tests pass
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

```
➜  ./gradlew test --tests ThreadCPUTests

> Task :test

org.opensearch.performanceanalyzer.commons.os.ThreadCPUTests > testMetrics STARTED

org.opensearch.performanceanalyzer.commons.os.ThreadCPUTests > testMetrics PASSED

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.6.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 6s
6 actionable tasks: 5 executed, 1 up-to-date
```
