### PR TITLE
remove unused SampleAggregators

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/commons/stats/ServiceMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/commons/stats/ServiceMetrics.java
@@ -21,9 +21,7 @@ import org.opensearch.performanceanalyzer.commons.stats.metrics.StatMetrics;
  */
 public class ServiceMetrics {
     public static SampleAggregator READER_METRICS_AGGREGATOR,
-            STAT_METRICS_AGGREGATOR = new SampleAggregator(StatMetrics.values()),
             COLLECTORS_METRICS_AGGREGATOR = new SampleAggregator(CollectorMetrics.values()),
-            PA_COLLECTORS_METRICS_AGGREGATOR,
             ERRORS_AND_EXCEPTIONS_AGGREGATOR = new SampleAggregator(ExceptionsAndErrors.values()),
             PERIODIC_SAMPLE_AGGREGATOR,
             RCA_GRAPH_METRICS_AGGREGATOR,
@@ -41,9 +39,7 @@ public class ServiceMetrics {
                 Stream.of(
                                 COMMONS_STAT_METRICS_AGGREGATOR,
                                 READER_METRICS_AGGREGATOR,
-                                STAT_METRICS_AGGREGATOR,
                                 COLLECTORS_METRICS_AGGREGATOR,
-                                PA_COLLECTORS_METRICS_AGGREGATOR,
                                 ERRORS_AND_EXCEPTIONS_AGGREGATOR,
                                 PERIODIC_SAMPLE_AGGREGATOR,
                                 RCA_GRAPH_METRICS_AGGREGATOR,


### PR DESCRIPTION
They seem to be remnants from past migrations and are no longer used anywhere in the codebase. (I checked all three repositories: PA, PA Commons, and PA RCA)