### PR TITLE
Adds OSMetrics Constants to the RTFMetrics

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/commons/metrics/RTFMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/commons/metrics/RTFMetrics.java
@@ -334,4 +334,23 @@ public class RTFMetrics {
             public static final String PACKET_PER_SEC_VALUE = "packets/s";
         }
     }
+
+    public enum OSMetrics {
+        CPU_UTILIZATION(AllMetrics.OSMetrics.Constants.CPU_VALUE);
+
+        private final String value;
+
+        OSMetrics(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+
+        public static class Constants {
+            public static final String CPU_VALUE = "CPU_Utilization";
+        }
+    }
 }


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
Add the OSMetrics enum in the RTFMetrics.
**Describe the solution you are proposing**
A clear and concise description of what you want to happen.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
