### PR TITLE
Update the maven snapshot publish endpoint and credential

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -20,14 +20,17 @@ jobs:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 21
       - uses: actions/checkout@v3
-      - uses: aws-actions/configure-aws-credentials@v1
+
+      - name: Load secret
+        uses: 1password/load-secrets-action@v2
         with:
-          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
-          aws-region: us-east-1
+          # Export loaded secrets as environment variables
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          SONATYPE_USERNAME: op://opensearch-infra-secrets/maven-central-portal-credentials/username
+          SONATYPE_PASSWORD: op://opensearch-infra-secrets/maven-central-portal-credentials/password
+
       - name: publish snapshots to maven
         run: |
-          export SONATYPE_USERNAME=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-username --query SecretString --output text)
-          export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
-          echo "::add-mask::$SONATYPE_USERNAME"
-          echo "::add-mask::$SONATYPE_PASSWORD"
           ./gradlew publishCreatePublicationToSnapshotsRepository

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ buildscript {
     repositories {
         mavenLocal()
         mavenCentral()
+        maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
         maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     }
 }
@@ -58,6 +59,7 @@ allprojects {
     repositories {
         mavenLocal()
         mavenCentral()
+        maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
         maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         maven { url "https://plugins.gradle.org/m2/" }
     }
@@ -226,7 +228,7 @@ publishing {
         if (buildVersion.toString().endsWith("SNAPSHOT")) {
             maven {
                 name = "Snapshots"
-                url = "https://aws.oss.sonatype.org/content/repositories/snapshots/"
+                url = "https://central.sonatype.com/repository/maven-snapshots/"
                 credentials {
                     username = System.getenv("SONATYPE_USERNAME")
                     password = System.getenv("SONATYPE_PASSWORD")


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
Update the Maven Snapshots publish URL in accordance with the recent Sonatype migration. 
https://central.sonatype.org/publish/publish-portal-snapshots/

We have stored the `onepassword` token in this `OpenSearch` repo secrets and new credentials for Sonatypes username & password have been stored in `onepassword`.  These credentials will be exported as env variables which used by maven publish.

**Related Issues**
Part of a campaign from https://github.com/opensearch-project/opensearch-build/issues/5551

**Describe the solution you are proposing**
A clear and concise description of what you want to happen.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
