### PR TITLE
Revert to Java 21

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 25
+          java-version: 21
       - uses: actions/checkout@v3
 
       - name: Load secret

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up JDK 25
         uses: actions/setup-java@v3
         with:
-          java-version: 25
+          java-version: 21
           distribution: 'temurin'
           cache: gradle
       - name: Build with Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -66,8 +66,8 @@ allprojects {
 }
 
 java {
-    targetCompatibility = JavaVersion.VERSION_25
-    sourceCompatibility = JavaVersion.VERSION_25
+    targetCompatibility = JavaVersion.VERSION_21
+    sourceCompatibility = JavaVersion.VERSION_21
 }
 
 apply plugin: 'java'

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=2.2.0
+version=2.1.1


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
Revert to JDK21 to stay compatible with performance-analyzer package as done in https://github.com/opensearch-project/performance-analyzer/pull/902. Without this change, we cannot consume new versions successfully.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-commons/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
